### PR TITLE
refactor: address code analysis warnings and mark CLS compliant

### DIFF
--- a/src/ColoredConsole.Test.ruleset
+++ b/src/ColoredConsole.Test.ruleset
@@ -2,7 +2,9 @@
 <RuleSet Name="ColoredConsole Test Rules" Description="ColoredConsole Test Rules" ToolsVersion="12.0">
   <Include Path="allrules.ruleset" Action="Error" />
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1014" Action="None" />
     <Rule Id="CA1016" Action="None" />
+    <Rule Id="CA1017" Action="None" />
     <Rule Id="CA2210" Action="None" />
   </Rules>
 </RuleSet>

--- a/src/ColoredConsole/StringExtensions.cs
+++ b/src/ColoredConsole/StringExtensions.cs
@@ -5,12 +5,18 @@
 namespace ColoredConsole
 {
     using System;
+    using System.Diagnostics.CodeAnalysis;
 
     /// <summary>
     /// Convenience extension methods for colorizing strings.
     /// </summary>
     public static class StringExtensions
     {
+        [SuppressMessage(
+            "Microsoft.Naming",
+            "CA1719:ParameterNamesShouldNotMatchMemberNames",
+            MessageId = "1#",
+            Justification = "By design.")]
         public static ColorToken Color(this string text, ConsoleColor? color)
         {
             return new ColorToken(text, color);

--- a/src/CommonAssemblyInfo.cs
+++ b/src/CommonAssemblyInfo.cs
@@ -21,4 +21,4 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyInformationalVersion("0.1.0")]
 
 [assembly: ComVisible(false)]
-[assembly: CLSCompliant(false)]
+[assembly: CLSCompliant(true)]


### PR DESCRIPTION
switch off in tests  - CA1014: Mark assemblies with CLSCompliantAttribute
switch off in tests  - CA1017: Mark assemblies with ComVisibleAttribute

relates to #4
