### PR TITLE
Parsed Color feature

### DIFF
--- a/src/ColoredConsole/ColoredConsole.csproj
+++ b/src/ColoredConsole/ColoredConsole.csproj
@@ -41,6 +41,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Guard.cs" />
+    <Compile Include="ParseColorString.cs" />
     <Compile Include="SystemConsole.cs" />
     <Compile Include="IConsole.cs" />
     <Compile Include="ColorToken.cs" />

--- a/src/ColoredConsole/ParseColorString.cs
+++ b/src/ColoredConsole/ParseColorString.cs
@@ -1,0 +1,112 @@
+// ColoredConsole - Copyright (c) 2017 CaptiveAire
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace ColoredConsole
+{
+    public class ParseColorString
+    {
+        public ParseColorString(char tokenDelimiter = '@')
+        {
+            this.TokenDelimiter = tokenDelimiter;
+        }
+
+        public char TokenDelimiter { get; }
+
+        IEnumerable<ColorCharacter> ParseAsCharacters(string input, ConsoleColor currentColor)
+        {
+            bool inColor = false;
+
+            var token = new StringBuilder();
+
+            foreach (var c in input)
+            {
+                if (inColor)
+                {
+                    if (c == this.TokenDelimiter)
+                    {
+                        if (token.Length == 0)
+                        {
+                            yield return new ColorCharacter(this.TokenDelimiter, currentColor);
+
+                            inColor = false;
+                        }
+                        else
+                        {
+                            // end...
+                            ConsoleColor value;
+                            if (Enum.TryParse(token.ToString(), true, out value))
+                            {
+                                currentColor = value;
+                            }
+
+                            inColor = false;
+                        }
+                    }
+                    else
+                    {
+                        token.Append(c);
+                    }
+                }
+                else if (c == this.TokenDelimiter)
+                {
+                    inColor = true;
+                    token.Clear();
+                }
+                else
+                {
+                    yield return new ColorCharacter(c, currentColor);
+                }
+            }
+        }
+
+        public IEnumerable<ColorToken> Parse(string input, ConsoleColor? initialForegroundColor = null)
+        {
+            if (string.IsNullOrEmpty(input))
+                yield break;
+
+            ConsoleColor currentColor = initialForegroundColor ?? Console.ForegroundColor;
+
+            var characterArray = this.ParseAsCharacters(input, currentColor).ToList();
+            var buffer = new List<ColorCharacter>();
+
+            // tokenize...
+            foreach (var c in characterArray)
+            {
+                if (c.ForegroundColor != currentColor)
+                {
+                    if (buffer.Any())
+                    {
+                        yield return new ColorToken(new string(buffer.Select(s => s.Value).ToArray()), currentColor);
+
+                        buffer.Clear();
+                    }
+
+                    currentColor = c.ForegroundColor;
+                }
+
+                buffer.Add(c);
+            }
+
+            if (buffer.Any())
+            {
+                yield return new ColorToken(new string(buffer.Select(s => s.Value).ToArray()), currentColor);
+            }
+        }
+
+        internal class ColorCharacter
+        {
+            internal ColorCharacter(char value, ConsoleColor foregroundColor)
+            {
+                this.Value = value;
+                this.ForegroundColor = foregroundColor;
+            }
+
+            public char Value { get; set; }
+            public ConsoleColor ForegroundColor { get; set; }
+        }
+    }
+}

--- a/src/ColoredConsole/StringExtensions.cs
+++ b/src/ColoredConsole/StringExtensions.cs
@@ -2,13 +2,11 @@
 //  Copyright (c) ColoredConsole contributors. (coloredconsole@gmail.com)
 // </copyright>
 
-using System.Collections;
-using System.Linq;
-
 namespace ColoredConsole
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
+    using System.Linq;
 
     /// <summary>
     /// Convenience extension methods for coloring instances of <see cref="string"/>.
@@ -27,14 +25,13 @@ namespace ColoredConsole
 
         /// <summary>
         /// Parses the text changing the colors based on color tokens @COLOR@ in the string.
-        /// Example:
-        /// 
-        /// "@BLUE@This is blue @RED@This is Red @GREEN@This is Green @WHITE@Etc."
+        /// Example: 
+        /// "@BLUE@This is blue @RED@This is Red @GREEN@This is Green @WHITE@Etc.".
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="initialColor">The initial color.</param>
-        /// <param name="tokenDelimiter">The color token delimiter (defaults to '@')</param>
-        /// <returns></returns>
+        /// <param name="tokenDelimiter">The color token delimiter (defaults to '@').</param>
+        /// <returns>Parsed ColorTokens array (always non-null).</returns>
         public static ColorToken[] ParseColor(this string text, ConsoleColor? initialColor = null, char tokenDelimiter = '@')
         {
             return new ParseColorString(tokenDelimiter).Parse(text, initialColor).ToArray();

--- a/src/ColoredConsole/StringExtensions.cs
+++ b/src/ColoredConsole/StringExtensions.cs
@@ -25,8 +25,8 @@ namespace ColoredConsole
 
         /// <summary>
         /// Parses the text changing the colors based on color tokens @COLOR@ in the string.
-        /// Example: 
-        /// "@BLUE@This is blue @RED@This is Red @GREEN@This is Green @WHITE@Etc.".
+        /// Example:
+        /// "@BLUE@This is Blue @RED@This is Red @GREEN@This is Green @WHITE@Etc.".
         /// </summary>
         /// <param name="text">The text.</param>
         /// <param name="initialColor">The initial color.</param>

--- a/src/ColoredConsole/StringExtensions.cs
+++ b/src/ColoredConsole/StringExtensions.cs
@@ -2,6 +2,9 @@
 //  Copyright (c) ColoredConsole contributors. (coloredconsole@gmail.com)
 // </copyright>
 
+using System.Collections;
+using System.Linq;
+
 namespace ColoredConsole
 {
     using System;
@@ -20,6 +23,21 @@ namespace ColoredConsole
         public static ColorToken Color(this string text, ConsoleColor? color)
         {
             return new ColorToken(text, color);
+        }
+
+        /// <summary>
+        /// Parses the text changing the colors based on color tokens @COLOR@ in the string.
+        /// Example:
+        /// 
+        /// "@BLUE@This is blue @RED@This is Red @GREEN@This is Green @WHITE@Etc."
+        /// </summary>
+        /// <param name="text">The text.</param>
+        /// <param name="initialColor">The initial color.</param>
+        /// <param name="tokenDelimiter">The color token delimiter (defaults to '@')</param>
+        /// <returns></returns>
+        public static ColorToken[] ParseColor(this string text, ConsoleColor? initialColor = null, char tokenDelimiter = '@')
+        {
+            return new ParseColorString(tokenDelimiter).Parse(text, initialColor).ToArray();
         }
 
         public static ColorToken Black(this string text)

--- a/src/test/ColoredConsole.Test.Acceptance/ColorConsoleFeature.cs
+++ b/src/test/ColoredConsole.Test.Acceptance/ColorConsoleFeature.cs
@@ -126,5 +126,39 @@ namespace ColoredConsole.Test.Acceptance
                     output[2].BackgroundColor.Should().Be(ConsoleColor.Cyan);
                 });
         }
+
+        [Scenario]
+        public static void WritingALineWithParsedStringColors(TestConsole console, string input, ColorToken[] output)
+        {
+            "Given a console"
+                .f(c => console = new TestConsole(ConsoleColor.White, ConsoleColor.Black).Using(c));
+
+            "And the text 'Hello ' in red and 'world' in blue"
+                .f(() => input = "@RED@Hello @BLUE@world");
+
+            "When I write a line containing the text"
+                .f(() => ColorConsole.WriteLine(input.ParseColor()));
+
+            "And look at the console"
+                .f(() => output = console.Tokens.ToArray());
+
+            "Then the console contains a line"
+                .f(() =>
+                    {
+                        output.Length.Should().Be(
+                            3, "there should be two tokens for the words and a token for the line ending");
+
+                        output[2].Text.Should().Be(Environment.NewLine, "the last token should be a new line");
+                    });
+
+            "And the line contains 'Hello ' in red and 'world' in blue"
+                .f(() =>
+                    {
+                        output[0].Text.Should().Be("Hello ");
+                        output[0].Color.Should().Be(ConsoleColor.Red);
+                        output[1].Text.Should().Be("world");
+                        output[1].Color.Should().Be(ConsoleColor.Blue);
+                    });
+        }
     }
 }


### PR DESCRIPTION
Adds an option to put color tokens in strings (e.g. "@RED@This is Red") instead of doing the fluent thing. A parsed string is easier for settings and templates.

Thanks.